### PR TITLE
Flaky fix gaffer 1

### DIFF
--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/OneOrMore.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/OneOrMore.java
@@ -24,14 +24,14 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 
 /**
  * A {@code OneOrMore} in an {@link Iterable} that allows items
- * to be added. It wraps an {@link ArrayList} or {@link HashSet} depending
+ * to be added. It wraps an {@link ArrayList} or {@link LinkedHashSet} depending
  * on whether deduplication is enabled.
  * This class is designed to be used in the case when the iterable quite often
  * just contains a single item. In the case only a single item is required, the class
@@ -61,7 +61,7 @@ public class OneOrMore<T> implements Iterable<T> {
         this.singleItem = item;
         if (deduplicate) {
             newCollection = k -> {
-                final Collection<T> collection = new HashSet<>();
+                final Collection<T> collection = new LinkedHashSet<>();
                 collection.add(k);
                 return collection;
             };

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/OneOrMore.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/OneOrMore.java
@@ -24,14 +24,14 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 
 /**
  * A {@code OneOrMore} in an {@link Iterable} that allows items
- * to be added. It wraps an {@link ArrayList} or {@link LinkedHashSet} depending
+ * to be added. It wraps an {@link ArrayList} or {@link TreeSet} depending
  * on whether deduplication is enabled.
  * This class is designed to be used in the case when the iterable quite often
  * just contains a single item. In the case only a single item is required, the class
@@ -61,7 +61,7 @@ public class OneOrMore<T> implements Iterable<T> {
         this.singleItem = item;
         if (deduplicate) {
             newCollection = k -> {
-                final Collection<T> collection = new LinkedHashSet<>();
+                final Collection<T> collection = new TreeSet<>();
                 collection.add(k);
                 return collection;
             };

--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.commonutil;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashSet;
+import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -97,7 +98,7 @@ public class OneOrMoreTest {
         // Given
         final boolean deduplicate = true;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
-        final Set<Integer> expectedItems = new LinkedHashSet<>();
+        final Set<Integer> expectedItems = new TreeSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When

--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
@@ -16,8 +16,7 @@
 package uk.gov.gchq.gaffer.commonutil;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -78,7 +77,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = false;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new LinkedHashSet<>();
+        final Set<Integer> expectedItems = new HashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When
@@ -108,7 +107,7 @@ public class OneOrMoreTest {
         }
 
         // Then
-        assertThat(collection).containsExactlyElementsOf(expectedItems);
+        assertThat(collection).containsExactlyInAnyOrderElementsOf(expectedItems);
     }
 
     @Test
@@ -117,7 +116,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = false;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new LinkedHashSet<>();
+        final Set<Integer> expectedItems = new HashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When
@@ -136,7 +135,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = true;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new LinkedHashSet<>();
+        final Set<Integer> expectedItems = new HashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When

--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java
@@ -17,7 +17,7 @@ package uk.gov.gchq.gaffer.commonutil;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -77,7 +77,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = false;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new HashSet<>();
+        final Set<Integer> expectedItems = new LinkedHashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When
@@ -97,7 +97,7 @@ public class OneOrMoreTest {
         // Given
         final boolean deduplicate = true;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
-        final Set<Integer> expectedItems = new HashSet<>();
+        final Set<Integer> expectedItems = new LinkedHashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When
@@ -116,7 +116,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = false;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new HashSet<>();
+        final Set<Integer> expectedItems = new LinkedHashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When
@@ -135,7 +135,7 @@ public class OneOrMoreTest {
         final boolean deduplicate = true;
         final OneOrMore<Integer> collection = new OneOrMore<>(deduplicate);
 
-        final Set<Integer> expectedItems = new HashSet<>();
+        final Set<Integer> expectedItems = new LinkedHashSet<>();
         IntStream.rangeClosed(1, 200).forEach(expectedItems::add);
 
         // When


### PR DESCRIPTION
The test : [uk.gov.gchq.gaffer.commonutil.OneOrMoreTest.shouldAddAllItemsWithDeduplicate](https://github.com/kevin952/Gaffer/blob/b8fd95d82f270d5f5332f347e4b1d6d05108d43e/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/OneOrMoreTest.java#L114)
You can view it here.

Lets Dive deeper into this Test and the fix provided for the issue:

**Flakiness:**
To check the flakiness of the test, I used a tool called **nondex**.

You can reproduce the test using the commands below:

   ```shell
   mvn install -pl core/common-util -am -DskipTests
   mvn -pl core/common-util test -Dtest=uk.gov.gchq.gaffer.commonutil.OneOrMoreTest#shouldAddAllItemsWithDeduplicate
  mvn -pl core/common-util edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=uk.gov.gchq.gaffer.commonutil.OneOrMoreTest#shouldAddAllItemsWithDeduplicate
```

Using the commands above I determined the test to be Flaky.

**Issue:**
According to the test, the ` deduplicate is set to True`  which implies that, there must not be any duplicates in the collection which is basically a HashSet.

The assertion on line 146 checks if the collection contains exactly the same elements as well as the the order of the set must be maintained. The developers have used a HashSet to ensure no duplication of elements.

**Fix:**
To address this, Initially, I introduced a fix ` LinkedHashSet ` data structure which not only ensures that duplication is avoided but also maintains the initial order of the set.

However, a fellow classmate suggested the fix maybe related to the assertion and not the data structure itself. This seemed like an interesting path to follow.  The idea behind this is, the assertion is too strict and I could find an assertion which only checks for the elements existence and not the order of the elements.

So,  I dove a bit deeper into the assertion called `assertThat(collection).containsExactlyElementsOf(expectedItems);`.
When I follow its definition, I get this, 
`  @Override
  public SELF containsExactlyElementsOf(Iterable<? extends ELEMENT> iterable) {
    return containsExactly(toArray(iterable));
  }`
```
  public void assertContainsExactly(AssertionInfo info, Iterable<?> actual, Object[] values) {
    checkIsNotNull(values);
    assertNotNull(info, actual);
    // use actualAsList instead of actual in case actual is a singly-passable iterable
    List<Object> actualAsList = newArrayList(actual);
    assertEquivalency(info, actual, values, actualAsList);
    assertElementOrder(info, actual, values, actualAsList);
  }
```

As you can clearly see, the return is a function call `ContainsExactly()`. This function makes sure that `deduplication` and order of the elements `assertElementOrder`.

So, I need to find a fix that does not consider the order of the elements.

**New Fix:**
I looked at other assertions which did not consider order and just considered the same elements. and I found this.
```containsExactlyInAnyOrderElementsOf()``` 

This function does not check for order and Ill update this with this fix and put out a new PR. I have tested this assertion and it passed the nondex test.
Hopefully, this clears out everything.

Do let me know if you any other questions! Please do put LGTM if you find this a good fix.